### PR TITLE
fix(keyboard): add proper keyboard handling for Android forms

### DIFF
--- a/src/screens/createEventScreen/index.tsx
+++ b/src/screens/createEventScreen/index.tsx
@@ -108,7 +108,7 @@ export const CreateEventScreen: React.FC<CreateEventScreenProps> = ({
     <SafeAreaView style={styles.container}>
       <KeyboardAvoidingView
         style={styles.container}
-        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
       >
         <View style={styles.header}>
           <View style={styles.headerRow}>

--- a/src/screens/editProfileScreen/index.tsx
+++ b/src/screens/editProfileScreen/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from 'react';
-import { View, ScrollView, TouchableOpacity, Image } from 'react-native';
+import { View, ScrollView, TouchableOpacity, Image, KeyboardAvoidingView, Platform } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { Text } from '@/components/ui/text';
@@ -122,11 +122,16 @@ export const EditProfileScreen: React.FC<EditProfileScreenProps> = ({
         </TouchableOpacity>
       </View>
 
-      <ScrollView
+      <KeyboardAvoidingView
         style={styles.scrollContainer}
-        contentContainerStyle={styles.contentContainer}
-        keyboardShouldPersistTaps="handled"
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        keyboardVerticalOffset={Platform.OS === 'ios' ? 100 : 0}
       >
+        <ScrollView
+          style={styles.scrollContainer}
+          contentContainerStyle={styles.contentContainer}
+          keyboardShouldPersistTaps="handled"
+        >
         <View style={styles.section}>
           <Text variant="titleSecondary" style={styles.sectionTitle}>
             Fotos
@@ -315,6 +320,7 @@ export const EditProfileScreen: React.FC<EditProfileScreenProps> = ({
           />
         </View>
       </ScrollView>
+      </KeyboardAvoidingView>
 
       <View style={styles.footer}>
         <Button

--- a/src/screens/loginScreen/components/LoginLayout/useLoginLayout.ts
+++ b/src/screens/loginScreen/components/LoginLayout/useLoginLayout.ts
@@ -6,7 +6,7 @@ export const useLoginLayout = (): UseLoginLayoutReturn => {
   const isPlatformIOS = useMemo(() => Platform.OS === 'ios', []);
 
   const keyboardBehavior = useMemo(
-    () => (isPlatformIOS ? 'padding' : undefined),
+    () => (isPlatformIOS ? 'padding' : 'height'),
     [isPlatformIOS]
   );
 


### PR DESCRIPTION
## 🐛 Bug Fix: Keyboard Overlapping Form Fields on Android

### Problem
Users reported that when typing in forms on Android, the keyboard would overlay the input fields, making it impossible to see what they were typing or access fields below the keyboard. This affected:
- Register screen
- Edit Profile screen
- Create Event screen
- Any other form-based screens

### Root Cause
The app was using `KeyboardAvoidingView` with `behavior={undefined}` for Android, which means the component was present but not doing anything. Additionally, EditProfileScreen was completely missing `KeyboardAvoidingView`.

**Code Issues:**
1. `useLoginLayout.ts`: `behavior: isPlatformIOS ? 'padding' : undefined` ❌
2. `createEventScreen/index.tsx`: `behavior={Platform.OS === 'ios' ? 'padding' : undefined}` ❌
3. `editProfileScreen/index.tsx`: No `KeyboardAvoidingView` at all ❌

### Solution
Changed Android `KeyboardAvoidingView` behavior from `undefined` to `'height'`, which properly adjusts the view height when keyboard appears.

**Changes Made:**

#### 1. LoginLayout (affects Register Screen)
```typescript
// Before
const keyboardBehavior = useMemo(
  () => (isPlatformIOS ? 'padding' : undefined),  // ❌ Android gets nothing
  [isPlatformIOS]
);

// After
const keyboardBehavior = useMemo(
  () => (isPlatformIOS ? 'padding' : 'height'),  // ✅ Android gets 'height'
  [isPlatformIOS]
);
```

#### 2. EditProfileScreen
```tsx
// Before - No KeyboardAvoidingView
<SafeAreaView>
  <ScrollView>{/* Form fields */}</ScrollView>
</SafeAreaView>

// After - Added KeyboardAvoidingView
<SafeAreaView>
  <KeyboardAvoidingView
    behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
    keyboardVerticalOffset={Platform.OS === 'ios' ? 100 : 0}
  >
    <ScrollView>{/* Form fields */}</ScrollView>
  </KeyboardAvoidingView>
</SafeAreaView>
```

#### 3. CreateEventScreen
```tsx
// Before
behavior={Platform.OS === 'ios' ? 'padding' : undefined}  // ❌

// After
behavior={Platform.OS === 'ios' ? 'padding' : 'height'}  // ✅
```

### Why `'height'` for Android?
- **iOS**: Uses `'padding'` - adds padding to avoid keyboard
- **Android**: Uses `'height'` - adjusts view height when keyboard appears
- **`undefined`**: Does nothing (old behavior causing the bug)

### Files Changed
- `src/screens/loginScreen/components/LoginLayout/useLoginLayout.ts`
- `src/screens/editProfileScreen/index.tsx`
- `src/screens/createEventScreen/index.tsx`

### Testing Checklist
- [ ] Test RegisterScreen on Android - type in all fields
- [ ] Test EditProfileScreen on Android - scroll and type
- [ ] Test CreateEventScreen on Android - fill form
- [ ] Verify keyboard doesn't overlap fields
- [ ] Verify fields auto-scroll into view when focused
- [ ] Test on iOS to ensure no regression

### Technical Notes
- AndroidManifest.xml already has `android:windowSoftInputMode="adjustResize"` ✅
- This works in conjunction with `KeyboardAvoidingView`
- No changes needed to web version (keyboard handling is browser-native)

### Impact
- **High Priority**: Fixes major usability issue on Android
- **Platforms Affected**: Primarily Android
- **User Experience**: Users can now complete forms without fighting the keyboard

### Related Issues
- Android Bug #5 from user testing round

🤖 Generated with [Claude Code](https://claude.com/claude-code)