### PR TITLE
fix(editProfile): clear city when state changes

### DIFF
--- a/src/screens/editProfileScreen/useEditProfileScreen.ts
+++ b/src/screens/editProfileScreen/useEditProfileScreen.ts
@@ -129,8 +129,24 @@ export const useEditProfileScreen = ({
       field: keyof EditProfileFormData,
       value: string | Date | boolean | null
     ) => {
-      setFormData(prev => ({ ...prev, [field]: value }));
-      setErrors(prev => ({ ...prev, [field]: undefined }));
+      setFormData(prev => {
+        // Special handling for state change: clear city
+        if (field === 'state' && prev.state !== value) {
+          return {
+            ...prev,
+            state: value as string,
+            city: '',  // Clear city when state changes
+          };
+        }
+        return { ...prev, [field]: value };
+      });
+
+      // Clear errors for both state and city when state changes
+      if (field === 'state') {
+        setErrors(prev => ({ ...prev, state: undefined, city: undefined }));
+      } else {
+        setErrors(prev => ({ ...prev, [field]: undefined }));
+      }
     },
     []
   );


### PR DESCRIPTION
## 🐛 Bug Fix: City Not Clearing When State Changes in EditProfile

### Problem
When editing profile, if the user changed the state selection, the previously selected city remained in the field, even though that city didn't exist in the new state.

**User Flow:**
1. User opens Edit Profile
2. Selects state: "São Paulo"
3. Selects city: "Campinas"
4. Changes state to: "Minas Gerais"
5. ❌ City field still shows "Campinas" (invalid for Minas Gerais)
6. CityDropdown fetches cities from Minas Gerais
7. "Campinas" is not in the new list
8. Form is in invalid state

### Root Cause
The generic `handleFieldChange` handler had no special logic for related fields:

**Problem Code:**
```typescript
// useEditProfileScreen.ts (old)
const handleFieldChange = useCallback(
  (field, value) => {
    setFormData(prev => ({ ...prev, [field]: value }));  // ❌ Generic update
    setErrors(prev => ({ ...prev, [field]: undefined }));  // ❌ Only clears one error
  },
  []
);
```

**Why This Doesn't Work:**
- State and city are **dependent fields**
- Changing state should cascade to clear city
- No logic to handle field relationships
- Same issue fixed in registerScreen (Bug #3), but not applied to editProfile

### Solution
Added conditional logic to clear city when state changes:

```typescript
const handleFieldChange = useCallback(
  (field, value) => {
    setFormData(prev => {
      // ✅ Special case: state change
      if (field === 'state' && prev.state !== value) {
        return {
          ...prev,
          state: value as string,
          city: '',  // Atomically clear city
        };
      }
      // Regular case
      return { ...prev, [field]: value };
    });

    // ✅ Clear errors for both fields
    if (field === 'state') {
      setErrors(prev => ({ ...prev, state: undefined, city: undefined }));
    } else {
      setErrors(prev => ({ ...prev, [field]: undefined }));
    }
  },
  []
);
```

### Key Features

#### 1. Atomic Update
Single `setFormData` call updates both state and city:
```typescript
return {
  ...prev,
  state: value as string,
  city: '',  // Updated in same render cycle
};
```

**Benefits:**
- No race conditions
- Predictable state transitions
- Single re-render

#### 2. Conditional Check
Only clears city if state **actually changes**:
```typescript
if (field === 'state' && prev.state !== value)
```

**Benefits:**
- Optimization: No unnecessary updates
- Preserves city if user selects same state again

#### 3. Error Clearing
Clears errors for both affected fields:
```typescript
setErrors(prev => ({ ...prev, state: undefined, city: undefined }));
```

**Benefits:**
- No stale error messages
- Clean form state

### Files Changed
- `src/screens/editProfileScreen/useEditProfileScreen.ts`
  - Modified `handleFieldChange` (lines 127-152)
  - Added special state/city handling
  - Added conditional error clearing

### Comparison with RegisterScreen Fix

Both screens now have **consistent** state/city handling:

| Screen | Bug # | Solution |
|--------|-------|----------|
| **RegisterScreen** | #3 | Separate `handleStateChange` handler |
| **EditProfileScreen** | #6 | Conditional logic in generic handler |

**Why Different Approaches?**
- **RegisterScreen:** Had separate handlers already (`handleStateChange`, `handleCityChange`)
- **EditProfileScreen:** Used generic `handleFieldChange` for all fields

Both achieve the same result: atomic state+city update.

### Testing Checklist
- [ ] Open Edit Profile screen
- [ ] Select state "São Paulo"
- [ ] Select city "Campinas"
- [ ] Note: City is visible and selected
- [ ] Change state to "Minas Gerais"
- [ ] **Verify:** City field is now empty ✅
- [ ] Open city dropdown
- [ ] **Verify:** Cities are from Minas Gerais
- [ ] Select a city from new state
- [ ] Save profile successfully

### Edge Cases Handled
- ✅ User selects same state again → City not cleared (optimization)
- ✅ User changes to empty state → City cleared
- ✅ User changes other fields (name, bio) → No impact on city
- ✅ Errors cleared correctly when state changes

### Impact
- **Priority:** Medium (confusing UX, but workaround exists)
- **Scope:** EditProfile screen only
- **User Experience:** Form now behaves predictably
- **Consistency:** Matches registerScreen behavior

### Related Issues
- Bug #6 from user testing: "Mudar estado não apaga a cidade selecionada no formulário de perfil"
- Related to Bug #3 (registerScreen) - same pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)