### PR TITLE
feat: add state/city dropdown selection in event filter

### DIFF
--- a/src/contexts/HomeFiltersContext.tsx
+++ b/src/contexts/HomeFiltersContext.tsx
@@ -16,6 +16,7 @@ import { FILTER_DEFAULTS } from '@/constants/filterDefaults';
 export interface ActiveFilters {
   sportIds?: string[];
   hasAvailableSpots?: boolean;
+  state?: string;
   city?: string;
   priceMin?: number;
   priceMax?: number;
@@ -176,7 +177,7 @@ export const HomeFiltersProvider: React.FC<HomeFiltersProviderProps> = ({
   }, []);
 
   const clearCityFilter = useCallback(() => {
-    setActiveFilters(prev => ({ ...prev, city: undefined }));
+    setActiveFilters(prev => ({ ...prev, state: undefined, city: undefined }));
   }, []);
 
   const buildApiFilters = useMemo((): EventsFilter | null => {
@@ -229,7 +230,7 @@ export const HomeFiltersProvider: React.FC<HomeFiltersProviderProps> = ({
     let count = 0;
 
     if (activeFilters.sportIds && activeFilters.sportIds.length > 0) count++;
-    if (activeFilters.city) count++;
+    if (activeFilters.state || activeFilters.city) count++;
     if (
       activeFilters.priceMin !== undefined ||
       activeFilters.priceMax !== undefined ||

--- a/src/screens/filterScreen/index.tsx
+++ b/src/screens/filterScreen/index.tsx
@@ -5,8 +5,9 @@ import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from '@/navigation/typesNavigation';
 import { useHomeFilters } from '@/contexts/HomeFiltersContext';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Checkbox } from '@/components/ui/checkbox';
+import { StateDropdown } from '@/components/ui/stateDropdown';
+import { CityDropdown } from '@/components/ui/cityDropdown';
 import { FilterSection } from './components/FilterSection';
 import { EventFilterSection } from './components/EventFilterSection';
 import { SportsFilter } from './components/SportsFilter';
@@ -47,8 +48,12 @@ export const FilterScreen: React.FC<FilterScreenProps> = ({ navigation }) => {
           case 'startDateTo':
             updateFilter(key, undefined);
             break;
+          case 'state':
+            updateFilter('state', undefined);
+            updateFilter('city', undefined);
+            break;
           case 'city':
-            updateFilter(key, '');
+            updateFilter(key, undefined);
             break;
           case 'isFree':
           case 'hasAvailableSpots':
@@ -173,20 +178,31 @@ export const FilterScreen: React.FC<FilterScreenProps> = ({ navigation }) => {
           <View style={styles.section}>
             <FilterSection
               title="Localização"
-              count={activeFilters.city ? 1 : 0}
+              count={activeFilters.state || activeFilters.city ? 1 : 0}
               testID="filter-location"
             >
               <View style={styles.locationInputs}>
-                <Input
-                  label="Cidade"
-                  value={activeFilters.city ?? ''}
-                  onChangeText={value =>
-                    updateFilter('city', value || undefined)
-                  }
-                  placeholder="Digite a cidade"
-                  testID="filter-city-input"
-                  fullWidth
+                <StateDropdown
+                  value={activeFilters.state ?? ''}
+                  onChange={value => {
+                    updateFilter('state', value || undefined);
+                    if (activeFilters.state && activeFilters.state !== value) {
+                      updateFilter('city', undefined);
+                    }
+                  }}
+                  label="Estado"
+                  testID="filter-state-dropdown"
                 />
+
+                {activeFilters.state && (
+                  <CityDropdown
+                    value={activeFilters.city ?? ''}
+                    onChange={value => updateFilter('city', value || undefined)}
+                    stateUF={activeFilters.state}
+                    label="Cidade"
+                    testID="filter-city-dropdown"
+                  />
+                )}
               </View>
             </FilterSection>
           </View>

--- a/src/screens/filterScreen/stylesFilterScreen.ts
+++ b/src/screens/filterScreen/stylesFilterScreen.ts
@@ -32,6 +32,6 @@ export const styles = StyleSheet.create({
     marginVertical: ArenaSpacing.sm,
   },
   locationInputs: {
-    gap: ArenaSpacing.sm,
+    gap: ArenaSpacing.md,
   },
 });


### PR DESCRIPTION
## Summary
- Replace free text input for city with StateDropdown and CityDropdown components
- Follow established pattern from createGroupScreen, registerScreen, and editProfileScreen
- Add state field to ActiveFilters interface

## Changes

### Context (`HomeFiltersContext.tsx`)
- ✅ Add `state?: string` field to `ActiveFilters` interface
- ✅ Update `clearCityFilter()` to clear both state and city
- ✅ Update `activeFiltersCount` to check `state` or `city`

### Filter Screen (`filterScreen/index.tsx`)
- ✅ Replace `<Input>` with `<StateDropdown>` + `<CityDropdown>`
- ✅ Add imports for StateDropdown and CityDropdown
- ✅ Update `handleRemoveFilter` to handle state removal (clears city too)
- ✅ Update FilterSection count: `count={activeFilters.state || activeFilters.city ? 1 : 0}`
- ✅ Conditional rendering: CityDropdown only shows when state is selected
- ✅ Auto-clear city when state changes

### Styles (`stylesFilterScreen.ts`)
- ✅ Update `locationInputs` gap from `ArenaSpacing.sm` to `ArenaSpacing.md` (12px)

## Benefits
- ✅ Consistent UX with other forms in the app
- ✅ Data validation via dropdown selection
- ✅ Cascading selection (select state first → then city)
- ✅ Uses existing IBGE API integration for cities
- ✅ Better mobile UX with search functionality in modals
- ✅ Prevents typos and invalid city names

## Components Reused
- `StateDropdown` - 27 Brazilian states (hardcoded)
- `CityDropdown` - Cities loaded dynamically via IBGE API
- `SelectionModal` - Modal with integrated search (used internally)

## Testing Checklist
- [ ] Open Filter Screen
- [ ] Select a state from StateDropdown
- [ ] Verify CityDropdown appears below state
- [ ] Select a city
- [ ] Verify both state and city appear in active filters
- [ ] Remove state filter → verify city is also removed
- [ ] Change state → verify city is cleared automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)