### PR TITLE
fix: prevent iOS password autofill freeze and yellow highlight bug

### DIFF
--- a/src/components/ui/input/inputVariants.ts
+++ b/src/components/ui/input/inputVariants.ts
@@ -1,3 +1,4 @@
+import { Platform } from 'react-native';
 import {
   ArenaColors,
   ArenaSpacing,
@@ -242,8 +243,12 @@ export const getInputTypeConfig = (
       keyboardType: 'default',
       autoCapitalize: 'none',
       secureTextEntry: true,
-      autoComplete: 'current-password',
-      textContentType: 'password',
+      autoComplete: Platform.select({
+        ios: 'off',
+        android: 'current-password',
+        default: 'off',
+      }),
+      textContentType: 'none',
     },
     phone: {
       keyboardType: 'phone-pad',

--- a/src/screens/loginScreen/components/LoginForm/components/LoginInputs/index.tsx
+++ b/src/screens/loginScreen/components/LoginForm/components/LoginInputs/index.tsx
@@ -36,7 +36,7 @@ export const LoginInputs: React.FC<LoginInputsProps> = React.memo(
           value={password}
           onChangeText={onPasswordChange}
           error={errors.password}
-          secureTextEntry={true}
+          type="password"
           fullWidth
           disableAnimations
           testID="password-input"


### PR DESCRIPTION
## 🐛 Problem

Critical iOS bug where accepting password suggestions from system autofill causes:
- 🟡 Password field stuck with permanent **yellow highlight**
- ⌨️ Keyboard becomes **unresponsive**
- 🚫 User **cannot dismiss keyboard** or leave the screen
- 💥 Form becomes **completely unusable**

### Reproduction Steps

1. Open Login or Register screen on iOS device (12+)
2. Focus password field
3. iOS suggests "Strong Password" above keyboard
4. Tap to accept suggestion
5. ❌ Field turns yellow and freezes
6. ❌ Cannot tap other fields or submit form

---

## 🔍 Root Cause

### Known React Native Bug

This is a **documented issue** in React Native with iOS 12+ Strong Password Autofill:
- [React Native Issue #31722](https://github.com/facebook/react-native/issues/31722): iOS Keyboard Autofill/SecureTextEntry content jump
- [React Native Issue #39411](https://github.com/facebook/react-native/issues/39411): Keyboard Flickering on secureTextEntry
- [React Native Issue #49933](https://github.com/facebook/react-native/issues/49933): Password suggestion shows in wrong field

### Technical Cause

When `TextInput` has:
```typescript
secureTextEntry={true}
autoComplete="current-password"
textContentType="password"  // ← Triggers iOS Strong Password UI
```

iOS autofill **interferes** with React Native's state management, causing:
1. Field maintains yellow highlight after selection
2. Keyboard `onBlur` events don't fire properly
3. `Keyboard.dismiss()` becomes non-functional
4. Touch events on other fields are blocked

---

## ✅ Solution

### Strategy: Platform-Specific Autofill Configuration

**iOS**: Disable autofill (prevents bug, necessary tradeoff)  
**Android**: Keep autofill enabled (no issues on Android)

### Changes Made

#### 1️⃣ **inputVariants.ts** - Platform-Specific Configuration

**Before**:
```typescript
password: {
  autoComplete: 'current-password',  // ❌ Causes iOS bug
  textContentType: 'password',       // ❌ Triggers Strong Password
}
```

**After**:
```typescript
import { Platform } from 'react-native';

password: {
  autoComplete: Platform.select({
    ios: 'off',                      // ✅ Disables iOS autofill
    android: 'current-password',     // ✅ Keeps Android autofill
    default: 'off',
  }),
  textContentType: 'none',           // ✅ Prevents iOS Strong Password UI
}
```

#### 2️⃣ **LoginInputs.tsx** - Fix Incorrect Pattern

**Before**:
```tsx
<Input
  label="Senha"
  secureTextEntry={true}  // ❌ Hardcoded, bypasses type system
/>
```

**After**:
```tsx
<Input
  label="Senha"
  type="password"         // ✅ Uses proper Input variant system
/>
```

**Why**: `type="password"` correctly applies all password-specific props from `inputVariants.ts`, including the new platform-specific configuration.

---

## 📊 Impact

| Aspect | Before | After |
|--------|--------|-------|
| **iOS Autofill** | 🟡 Freezes field | ✅ Disabled (no freeze) |
| **iOS Manual Entry** | ✅ Works | ✅ Works |
| **Android Autofill** | ✅ Works | ✅ Still works |
| **Android Manual Entry** | ✅ Works | ✅ Works |
| **User Experience** | 💥 Form breaks | ✅ Smooth experience |

### Tradeoffs

✅ **Pros**:
- Fixes critical blocking bug on iOS
- Users can now complete forms on iOS
- Maintains full functionality on Android
- No code duplication (DRY principle)

⚠️ **Cons**:
- iOS users lose password autofill convenience
- Must manually type or use password manager apps (1Password, LastPass still work)

**Decision**: This is a **necessary tradeoff** until React Native fixes the underlying issue. A broken form is worse than no autofill.

---

## 🧪 Testing Checklist

### iOS Testing
- [ ] Open Login screen on iOS device (12+)
- [ ] Focus password field
- [ ] Verify no yellow "Strong Password" suggestion appears
- [ ] Type password manually
- [ ] Verify field behaves normally (no freeze)
- [ ] Tap submit button
- [ ] Verify keyboard dismisses correctly
- [ ] Test RegisterScreen (2 password fields)
- [ ] Verify both password fields work without freezing

### Android Testing
- [ ] Open Login screen on Android device
- [ ] Focus password field
- [ ] Verify autofill suggestions appear normally
- [ ] Select autofill suggestion
- [ ] Verify field populates correctly (no freeze)
- [ ] Test RegisterScreen
- [ ] Verify autofill works for both password fields

### Cross-Platform
- [ ] Manual password entry works on both platforms
- [ ] Keyboard navigation between fields works
- [ ] Form submission works correctly
- [ ] No console errors or warnings

---

## 📚 References

### React Native Issues
- [#31722](https://github.com/facebook/react-native/issues/31722) - iOS Keyboard Autofill/SecureTextEntry content jump
- [#39411](https://github.com/facebook/react-native/issues/39411) - Keyboard Flickering on secureTextEntry
- [#49933](https://github.com/facebook/react-native/issues/49933) - TextInput shows password suggestion in wrong field

### Community Solutions
- [Stack Overflow: Disable Password AutoFill on iOS](https://stackoverflow.com/questions/48489479/)
- [Stack Overflow: secureTextEntry Disable iOS 13+ Strong Password](https://stackoverflow.com/questions/59038086/)

### Official Documentation
- [React Native TextInput](https://reactnative.dev/docs/textinput)
- [Apple Password AutoFill](https://developer.apple.com/documentation/security/password_autofill)

---

## 🔄 Future Improvements

Monitor React Native releases for upstream fix:
- If React Native fixes the autofill bug in future version
- Revert this change to re-enable iOS autofill
- Track [#31722](https://github.com/facebook/react-native/issues/31722) for updates

Consider alternative solutions:
- Implement third-party password manager integration (e.g., OnePassword SDK)
- Explore React Native community packages for better autofill handling

---

## 📝 Files Changed

1. `src/components/ui/input/inputVariants.ts`
   - Added Platform import
   - Updated password variant with Platform.select
   - Changed textContentType to 'none'

2. `src/screens/loginScreen/components/LoginForm/components/LoginInputs/index.tsx`
   - Removed hardcoded secureTextEntry prop
   - Replaced with type="password" (correct pattern)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)