### PR TITLE
fix: auto-select first sport as favorite in edit profile

### DIFF
--- a/src/screens/editProfileScreen/useEditProfileScreen.ts
+++ b/src/screens/editProfileScreen/useEditProfileScreen.ts
@@ -164,6 +164,7 @@ export const useEditProfileScreen = ({
             prev.primarySportId === sportId ? null : prev.primarySportId,
         };
       } else {
+        const isFirstSport = prev.selectedSports.length === 0;
         return {
           ...prev,
           selectedSports: [...prev.selectedSports, sportId],
@@ -171,6 +172,7 @@ export const useEditProfileScreen = ({
             ...prev.sportLevels,
             [sportId]: SkillLevel.INTERMEDIATE,
           },
+          primarySportId: isFirstSport ? sportId : prev.primarySportId,
         };
       }
     });


### PR DESCRIPTION
## Summary
Corrige bug onde adicionar primeiro esporte não marcava automaticamente como favorito.

## Problem
Quando o usuário selecionava seu primeiro esporte no EditProfile, ele não era automaticamente marcado como favorito (`primarySportId`). O usuário tinha que clicar manualmente no checkbox de "favorito".

## Solution
- Detecta se é o primeiro esporte (`selectedSports.length === 0`)
- Se sim, marca automaticamente como `primarySportId`
- Esportes subsequentes não são auto-favoritados (escolha do usuário)

## Changes
- Modified `handleToggleSport` in `useEditProfileScreen.ts` (lines 167-176)
- Added `isFirstSport` check
- Conditional `primarySportId` assignment

## Test Plan
- [x] Add first sport → Auto-favorited ✓
- [x] Add second sport → Not auto-favorited ✓
- [x] Remove favorite sport → primarySportId becomes null ✓
- [x] Change sport level → Favorite status unchanged ✓

**Bug fix**: Closes issue #1 (Favorito automático)

🤖 Generated with [Claude Code](https://claude.com/claude-code)