### PR TITLE
fix: hide edit FAB when scrolling to bottom in group details

### DIFF
--- a/src/screens/groupDetailsScreen/index.tsx
+++ b/src/screens/groupDetailsScreen/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react';
-import { View, ScrollView } from 'react-native';
+import { View, ScrollView, NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { Text } from '@/components/ui/text';
 import { Button } from '@/components/ui/button';
@@ -52,6 +52,7 @@ export const GroupDetailsScreen: React.FC<GroupDetailsScreenProps> = ({
 
   const [showAllMembers, setShowAllMembers] = useState(false);
   const [showInviteModal, setShowInviteModal] = useState(false);
+  const [showFab, setShowFab] = useState(true);
 
   const { statistics, isLoading: isLoadingStats } = useGroupStatistics(groupId);
 
@@ -75,6 +76,14 @@ export const GroupDetailsScreen: React.FC<GroupDetailsScreenProps> = ({
   const handleGoBack = useCallback(() => {
     navigation.goBack();
   }, [navigation]);
+
+  const handleScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const scrollY = event.nativeEvent.contentOffset.y;
+      setShowFab(scrollY <= 100);
+    },
+    []
+  );
 
   const isMember = group?.currentUserStatus === 'MEMBER';
   const canManage =
@@ -109,6 +118,8 @@ export const GroupDetailsScreen: React.FC<GroupDetailsScreenProps> = ({
       <ScrollView
         style={styles.container}
         contentContainerStyle={styles.scrollContent}
+        onScroll={handleScroll}
+        scrollEventThrottle={16}
       >
         <ProfileHeroSection
           {...mapGroupToHeroData(group)}
@@ -263,7 +274,7 @@ export const GroupDetailsScreen: React.FC<GroupDetailsScreenProps> = ({
         isLoading={actionLoading}
       />
 
-      {canManage && (
+      {canManage && showFab && (
         <Fab
           variant="primary"
           size="md"


### PR DESCRIPTION
## Summary
Corrige sobreposição do FAB "Editar" sobre o botão "Convidar Membros" ao rolar a tela.

## Problem
O FAB (floating action button) de editar grupo ficava fixo na tela, sobrepondo o botão "Convidar Membros" quando o usuário rolava até o final da página.

## Solution
- Detecta posição do scroll (`scrollY`)
- Esconde FAB quando `scrollY > 100px`
- Mostra FAB quando usuário rola de volta para cima (`scrollY <= 100px`)

## Changes
- Added `showFab` state to `GroupDetailsScreen`
- Added `handleScroll` callback to track scroll position
- Added `onScroll` and `scrollEventThrottle={16}` to `ScrollView`
- Modified FAB render condition: `{canManage && showFab && ...}`

## Test Plan
- [x] FAB visible at top of screen
- [x] FAB hides when scrolling down past 100px
- [x] FAB shows when scrolling back to top
- [x] "Convidar Membros" button accessible without FAB overlap

**Bug fix**: Closes issue #2 (Botão editar sobre adicionar membros)

🤖 Generated with [Claude Code](https://claude.com/claude-code)