### PR TITLE
feat: add complete friendship management flow to user profile

### DIFF
--- a/src/screens/profileScreen/components/FriendshipActions/index.tsx
+++ b/src/screens/profileScreen/components/FriendshipActions/index.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { View } from 'react-native';
+import { Button } from '@/components/ui/button';
+import { useFriendshipActions } from './useFriendshipActions';
+import { FriendshipActionsProps } from './typesFriendshipActions';
+import { styles } from './stylesFriendshipActions';
+
+export const FriendshipActions: React.FC<FriendshipActionsProps> = ({
+  userId,
+  onStatusChange,
+}) => {
+  const {
+    actionType,
+    isLoading,
+    handleSendRequest,
+    handleCancelRequest,
+    handleAcceptRequest,
+    handleRejectRequest,
+    handleRemoveFriend,
+  } = useFriendshipActions(userId, onStatusChange);
+
+  if (actionType === 'loading') {
+    return null;
+  }
+
+  if (actionType === 'none') {
+    return (
+      <View style={styles.container}>
+        <Button
+          variant="primary"
+          size="lg"
+          onPress={handleSendRequest}
+          loading={isLoading}
+          fullWidth
+        >
+          Adicionar Amigo
+        </Button>
+      </View>
+    );
+  }
+
+  if (actionType === 'pending_sent') {
+    return (
+      <View style={styles.container}>
+        <Button
+          variant="subtle"
+          size="lg"
+          onPress={handleCancelRequest}
+          loading={isLoading}
+          fullWidth
+        >
+          Cancelar Solicitação
+        </Button>
+      </View>
+    );
+  }
+
+  if (actionType === 'pending_received') {
+    return (
+      <View style={styles.container}>
+        <View style={styles.buttonsRow}>
+          <View style={{ flex: 1 }}>
+            <Button
+              variant="primary"
+              size="lg"
+              onPress={handleAcceptRequest}
+              loading={isLoading}
+              fullWidth
+            >
+              Aceitar
+            </Button>
+          </View>
+          <View style={{ flex: 1 }}>
+            <Button
+              variant="subtle"
+              size="lg"
+              onPress={handleRejectRequest}
+              loading={isLoading}
+              fullWidth
+            >
+              Recusar
+            </Button>
+          </View>
+        </View>
+      </View>
+    );
+  }
+
+  if (actionType === 'accepted') {
+    return (
+      <View style={styles.container}>
+        <Button
+          variant="destructive"
+          size="lg"
+          onPress={handleRemoveFriend}
+          loading={isLoading}
+          fullWidth
+        >
+          Remover Amigo
+        </Button>
+      </View>
+    );
+  }
+
+  return null;
+};

--- a/src/screens/profileScreen/components/FriendshipActions/stylesFriendshipActions.ts
+++ b/src/screens/profileScreen/components/FriendshipActions/stylesFriendshipActions.ts
@@ -1,0 +1,12 @@
+import { StyleSheet } from 'react-native';
+import { ArenaSpacing } from '@/constants';
+
+export const styles = StyleSheet.create({
+  container: {
+    marginBottom: ArenaSpacing.md,
+  },
+  buttonsRow: {
+    flexDirection: 'row',
+    gap: ArenaSpacing.sm,
+  },
+});

--- a/src/screens/profileScreen/components/FriendshipActions/typesFriendshipActions.ts
+++ b/src/screens/profileScreen/components/FriendshipActions/typesFriendshipActions.ts
@@ -1,0 +1,18 @@
+export interface FriendshipActionsProps {
+  userId: string;
+  onStatusChange?: () => void;
+}
+
+export type FriendshipActionType =
+  | 'none'
+  | 'pending_sent'
+  | 'pending_received'
+  | 'accepted'
+  | 'loading';
+
+export interface FriendshipData {
+  status: string | null;
+  friendshipId?: string;
+  requesterId?: string;
+  addresseeId?: string;
+}

--- a/src/screens/profileScreen/components/FriendshipActions/useFriendshipActions.ts
+++ b/src/screens/profileScreen/components/FriendshipActions/useFriendshipActions.ts
@@ -1,0 +1,150 @@
+import { useState, useCallback, useEffect } from 'react';
+import { friendshipsApi } from '@/services/friendships/friendshipsApi';
+import { useAuth } from '@/contexts/AuthContext';
+import { useNotification } from '@/contexts/NotificationContext';
+import { FriendshipData, FriendshipActionType } from './typesFriendshipActions';
+
+interface UseFriendshipActionsReturn {
+  actionType: FriendshipActionType;
+  isLoading: boolean;
+  handleSendRequest: () => Promise<void>;
+  handleCancelRequest: () => Promise<void>;
+  handleAcceptRequest: () => Promise<void>;
+  handleRejectRequest: () => Promise<void>;
+  handleRemoveFriend: () => Promise<void>;
+}
+
+export const useFriendshipActions = (
+  userId: string,
+  onStatusChange?: () => void
+): UseFriendshipActionsReturn => {
+  const { user: currentUser } = useAuth();
+  const { showSuccess, showError } = useNotification();
+  const [friendshipData, setFriendshipData] = useState<FriendshipData | null>(
+    null
+  );
+  const [isLoading, setIsLoading] = useState(false);
+  const [isInitialLoading, setIsInitialLoading] = useState(true);
+
+  const fetchFriendshipStatus = useCallback(async () => {
+    if (!userId) return;
+
+    try {
+      setIsInitialLoading(true);
+      const response = await friendshipsApi.getFriendshipStatus(userId);
+      setFriendshipData(response as FriendshipData);
+    } catch (error) {
+      setFriendshipData({ status: null });
+    } finally {
+      setIsInitialLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    fetchFriendshipStatus();
+  }, [fetchFriendshipStatus]);
+
+  const getActionType = useCallback((): FriendshipActionType => {
+    if (isInitialLoading) return 'loading';
+    if (!friendshipData || friendshipData.status === null) return 'none';
+
+    if (friendshipData.status === 'PENDING') {
+      return friendshipData.requesterId === currentUser?.id
+        ? 'pending_sent'
+        : 'pending_received';
+    }
+
+    if (friendshipData.status === 'ACCEPTED') return 'accepted';
+
+    return 'none';
+  }, [friendshipData, currentUser, isInitialLoading]);
+
+  const handleSendRequest = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      await friendshipsApi.sendFriendRequest({ addresseeId: userId });
+      showSuccess('Solicitação enviada com sucesso');
+      await fetchFriendshipStatus();
+      onStatusChange?.();
+    } catch (error) {
+      showError('Erro ao enviar solicitação de amizade');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [userId, fetchFriendshipStatus, onStatusChange, showSuccess, showError]);
+
+  const handleCancelRequest = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      await friendshipsApi.cancelFriendRequest(userId);
+      showSuccess('Solicitação cancelada');
+      await fetchFriendshipStatus();
+      onStatusChange?.();
+    } catch (error) {
+      showError('Erro ao cancelar solicitação');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [userId, fetchFriendshipStatus, onStatusChange, showSuccess, showError]);
+
+  const handleAcceptRequest = useCallback(async () => {
+    if (!friendshipData) return;
+
+    try {
+      setIsLoading(true);
+      await friendshipsApi.acceptFriendRequest(userId);
+      showSuccess('Solicitação aceita');
+      await fetchFriendshipStatus();
+      onStatusChange?.();
+    } catch (error) {
+      showError('Erro ao aceitar solicitação');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [
+    userId,
+    friendshipData,
+    fetchFriendshipStatus,
+    onStatusChange,
+    showSuccess,
+    showError,
+  ]);
+
+  const handleRejectRequest = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      await friendshipsApi.rejectFriendRequest(userId);
+      showSuccess('Solicitação recusada');
+      await fetchFriendshipStatus();
+      onStatusChange?.();
+    } catch (error) {
+      showError('Erro ao recusar solicitação');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [userId, fetchFriendshipStatus, onStatusChange, showSuccess, showError]);
+
+  const handleRemoveFriend = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      await friendshipsApi.removeFriend(userId);
+      showSuccess('Amizade removida');
+      await fetchFriendshipStatus();
+      onStatusChange?.();
+    } catch (error) {
+      showError('Erro ao remover amizade');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [userId, fetchFriendshipStatus, onStatusChange, showSuccess, showError]);
+
+  return {
+    actionType: getActionType(),
+    isLoading,
+    handleSendRequest,
+    handleCancelRequest,
+    handleAcceptRequest,
+    handleRejectRequest,
+    handleRemoveFriend,
+  };
+};

--- a/src/screens/profileScreen/index.tsx
+++ b/src/screens/profileScreen/index.tsx
@@ -15,6 +15,7 @@ import { ProfileInfoSection } from './components/ProfileInfoSection';
 import { ProfileBioSection } from './components/ProfileBioSection';
 import { ProfileStatsSection } from './components/ProfileStatsSection';
 import { ProfileGroupsSection } from './components/ProfileGroupsSection';
+import { FriendshipActions } from './components/FriendshipActions';
 import {
   mapUserToDisplayData,
   getInitials,
@@ -105,6 +106,10 @@ export const ProfileScreen: React.FC<ProfileScreenProps> = ({
             isEmailVerified={user.isEmailVerified}
             memberSince={formatMemberSince(user.createdAt)}
           />
+
+          {!isOwnProfile && userId && (
+            <FriendshipActions userId={userId} onStatusChange={refetch} />
+          )}
 
           <ProfileBioSection bio={displayData.bio} />
 


### PR DESCRIPTION
## Summary
Adiciona sistema completo de gerenciamento de amizade na tela de perfil do usuário.

## Features
**5 Estados de Amizade**:
1. ✅ **Nenhuma relação** → Botão "Adicionar Amigo"
2. ✅ **Solicitação enviada** → Botão "Cancelar Solicitação"
3. ✅ **Solicitação recebida** → Botões "Aceitar" / "Recusar"
4. ✅ **Amigos** → Botão "Remover Amigo"
5. ✅ **Loading** → Estado oculto durante fetch

## Components Created
```
src/screens/profileScreen/components/FriendshipActions/
├── index.tsx                      # Main component
├── useFriendshipActions.ts        # Friendship logic hook
├── typesFriendshipActions.ts      # TypeScript types
└── stylesFriendshipActions.ts     # Styles
```

## Implementation Details
**Hook (`useFriendshipActions.ts`)**:
- Fetches friendship status on mount
- Determines action type based on status
- Handles all 5 friendship actions
- Loading and error states
- Success/error notifications

**Component (`index.tsx`)**:
- Renders appropriate buttons per state
- Disabled during loading
- Full-width responsive layout
- Uses Arena Design System components

**Integration (`ProfileScreen`)**:
- Only shown when `!isOwnProfile`
- Positioned after ProfileInfoSection
- Calls `refetch()` on status change

## API Integration
- `getFriendshipStatus(userId)` - Get current status
- `sendFriendRequest()` - Send request
- `cancelFriendRequest()` - Cancel outgoing
- `acceptFriendRequest()` - Accept incoming
- `rejectFriendRequest()` - Reject incoming
- `removeFriend()` - Remove friendship

## Test Plan
- [x] Visit user profile → "Adicionar Amigo" appears
- [x] Send request → Button changes to "Cancelar Solicitação"
- [x] Cancel request → Button returns to "Adicionar Amigo"
- [x] Receive request → "Aceitar"/"Recusar" buttons appear
- [x] Accept request → Button changes to "Remover Amigo"
- [x] Remove friend → Button returns to "Adicionar Amigo"
- [x] All actions show success/error notifications

**Bug fix**: Closes issue #6 (Fluxo de amizade)

🤖 Generated with [Claude Code](https://claude.com/claude-code)