### PR TITLE
feat: display past events in accordion on MyEvents screen

### DIFF
--- a/src/screens/myEventsScreen/index.tsx
+++ b/src/screens/myEventsScreen/index.tsx
@@ -3,6 +3,7 @@ import { View, FlatList, ListRenderItem } from 'react-native';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { Text } from '@/components/ui/text';
 import { SportsLoading } from '@/components/ui/sportsLoading';
+import { AccordionSection } from '@/components/accordionSection';
 import { AppLayout } from '@/components/AppLayout';
 import { ArenaColors } from '@/constants';
 import { EventCard } from '@/screens/homeScreen/components/EventCard';
@@ -24,6 +25,7 @@ export const MyEventsScreen: React.FC<MyEventsScreenProps> = ({
 }) => {
   const {
     groupedEvents,
+    pastEvents,
     isLoading,
     isLoadingMore,
     hasMore,
@@ -81,14 +83,42 @@ export const MyEventsScreen: React.FC<MyEventsScreenProps> = ({
   }, [isLoading, eventFilter]);
 
   const renderFooter = useCallback(() => {
-    if (!isLoadingMore) return null;
-
     return (
-      <View style={styles.loadingFooter}>
-        <SportsLoading size="sm" animationSpeed="fast" />
-      </View>
+      <>
+        {isLoadingMore && (
+          <View style={styles.loadingFooter}>
+            <SportsLoading size="sm" animationSpeed="fast" />
+          </View>
+        )}
+        {pastEvents.length > 0 && (
+          <AccordionSection
+            title="Eventos Passados"
+            count={pastEvents.length}
+            defaultExpanded={false}
+          >
+            {pastEvents.map(event => (
+              <View key={event.id} style={styles.eventCardContainer}>
+                <EventCard
+                  event={event}
+                  onDetailsPress={handleDetailsPress}
+                  onManagePress={undefined}
+                  onShare={handleShare}
+                  onJoinEvent={undefined}
+                  onRequestJoin={undefined}
+                  onCancelParticipation={undefined}
+                  onUndoRequest={undefined}
+                  onAcceptInvitation={undefined}
+                  onRejectInvitation={undefined}
+                  isActionLoading={false}
+                  currentActionEventId={null}
+                />
+              </View>
+            ))}
+          </AccordionSection>
+        )}
+      </>
     );
-  }, [isLoadingMore]);
+  }, [isLoadingMore, pastEvents, handleDetailsPress, handleShare]);
 
   const keyExtractor = useCallback((item: GroupedEventItem, index: number) => {
     if (item.type === 'header') {

--- a/src/screens/myEventsScreen/typesMyEventsScreen.ts
+++ b/src/screens/myEventsScreen/typesMyEventsScreen.ts
@@ -39,6 +39,7 @@ export interface MyEventsScreenProps {
 export interface UseMyEventsScreenReturn {
   events: Event[];
   groupedEvents: GroupedEventItem[];
+  pastEvents: Event[];
   isLoading: boolean;
   isRefreshing: boolean;
   isLoadingMore: boolean;

--- a/src/screens/myEventsScreen/useMyEventsScreen.ts
+++ b/src/screens/myEventsScreen/useMyEventsScreen.ts
@@ -7,7 +7,7 @@ import {
   EventFilterType,
 } from './typesMyEventsScreen';
 import { useMyEvents } from './hooks/useMyEvents';
-import { groupEventsByTime } from './utils/eventGrouping';
+import { groupEventsByTime, getPastEvents } from './utils/eventGrouping';
 import { useEventActions } from '@/hooks/useEventActions';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
@@ -38,6 +38,10 @@ export const useMyEventsScreen = (): UseMyEventsScreenReturn => {
     return groupEventsByTime(events);
   }, [events]);
 
+  const pastEvents = useMemo(() => {
+    return getPastEvents(events);
+  }, [events]);
+
   const eventActions = useEventActions(refreshEvents);
 
   const handleFilterChange = useCallback((filter: EventFilterType) => {
@@ -65,6 +69,7 @@ export const useMyEventsScreen = (): UseMyEventsScreenReturn => {
   return {
     events,
     groupedEvents,
+    pastEvents,
     isLoading,
     isRefreshing,
     isLoadingMore,

--- a/src/screens/myEventsScreen/utils/eventGrouping.ts
+++ b/src/screens/myEventsScreen/utils/eventGrouping.ts
@@ -77,6 +77,19 @@ export const categorizeEvent = (event: Event): TimeCategory => {
 };
 
 export const groupEventsByTime = (events: Event[]): GroupedEventItem[] => {
+  const currentDate = new Date();
+  const futureEvents: Event[] = [];
+  const pastEvents: Event[] = [];
+
+  events.forEach(event => {
+    const eventDate = new Date(event.startDate);
+    if (eventDate > currentDate) {
+      futureEvents.push(event);
+    } else {
+      pastEvents.push(event);
+    }
+  });
+
   const grouped: Record<TimeCategory, Event[]> = {
     today: [],
     tomorrow: [],
@@ -85,7 +98,7 @@ export const groupEventsByTime = (events: Event[]): GroupedEventItem[] => {
     upcoming: [],
   };
 
-  events.forEach(event => {
+  futureEvents.forEach(event => {
     const category = categorizeEvent(event);
     grouped[category].push(event);
   });
@@ -111,6 +124,14 @@ export const groupEventsByTime = (events: Event[]): GroupedEventItem[] => {
   });
 
   return result;
+};
+
+export const getPastEvents = (events: Event[]): Event[] => {
+  const currentDate = new Date();
+  return events.filter(event => {
+    const eventDate = new Date(event.startDate);
+    return eventDate <= currentDate;
+  });
 };
 
 export const getCategoryLabel = (category: TimeCategory): string => {

--- a/src/utils/eventHelpers.ts
+++ b/src/utils/eventHelpers.ts
@@ -1,0 +1,30 @@
+import { Event } from '@/services/events/typesEvents';
+
+export interface SeparatedEvents {
+  futureEvents: Event[];
+  pastEvents: Event[];
+}
+
+export const separateEventsByDate = (events: Event[]): SeparatedEvents => {
+  const currentDate = new Date();
+
+  const futureEvents: Event[] = [];
+  const pastEvents: Event[] = [];
+
+  events.forEach(event => {
+    const eventStartDate = new Date(event.startDate);
+    if (eventStartDate > currentDate) {
+      futureEvents.push(event);
+    } else {
+      pastEvents.push(event);
+    }
+  });
+
+  return { futureEvents, pastEvents };
+};
+
+export const isPastEvent = (event: Event): boolean => {
+  const currentDate = new Date();
+  const eventStartDate = new Date(event.startDate);
+  return eventStartDate <= currentDate;
+};


### PR DESCRIPTION
## Summary
- Created `separateEventsByDate()` utility function to split events into future and past
- Modified event grouping logic to filter out past events from main time categories (Hoje, Amanhã, Esta Semana, etc.)
- Added collapsible accordion section for past events in MyEventsScreen
- Past events are view-only (all action buttons disabled)
- Verified other screens already correctly filter past events

## Changes
### New Files
- `src/utils/eventHelpers.ts` - Utility function `separateEventsByDate()`

### Modified Files
- `src/screens/myEventsScreen/utils/eventGrouping.ts`
  - Separated future and past events in `groupEventsByTime()`
  - Added `getPastEvents()` function
  
- `src/screens/myEventsScreen/useMyEventsScreen.ts`
  - Added `pastEvents` state using `getPastEvents()`
  - Exposed `pastEvents` in hook return
  
- `src/screens/myEventsScreen/index.tsx`
  - Added AccordionSection component for past events
  - Integrated into `renderFooter` function
  - Past events render with all actions set to `undefined` (view-only)
  
- `src/screens/myEventsScreen/typesMyEventsScreen.ts`
  - Added `pastEvents` to hook return interface

## Verification
Confirmed other screens already handle past events correctly:
- **HomeScreen**: `filterFutureEvents()` already excludes past events
- **GroupDetailsScreen**: Doesn't display events (only group members)
- **ProfileScreen**: Only displays groups, not events

## Test plan
- [ ] Open MyEvents screen
- [ ] Verify future events display in normal categories (Hoje, Amanhã, etc.)
- [ ] Verify past events appear in collapsed "Eventos Passados" accordion at bottom
- [ ] Expand accordion and verify past events are visible
- [ ] Verify past events have no action buttons (view-only)
- [ ] Verify event count in accordion title matches number of past events
- [ ] Open HomeScreen and verify no past events are displayed
- [ ] Test all event filters (all, organizing, participating, invited)

🤖 Generated with [Claude Code](https://claude.com/claude-code)