### PR TITLE
chore: fix lint and prettier errors

### DIFF
--- a/src/screens/groupDetailsScreen/index.tsx
+++ b/src/screens/groupDetailsScreen/index.tsx
@@ -1,5 +1,10 @@
 import React, { useCallback, useState } from 'react';
-import { View, ScrollView, NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
+import {
+  View,
+  ScrollView,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+} from 'react-native';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { Text } from '@/components/ui/text';
 import { Button } from '@/components/ui/button';

--- a/src/screens/homeScreen/components/EventCard/typesEventCard.ts
+++ b/src/screens/homeScreen/components/EventCard/typesEventCard.ts
@@ -9,8 +9,14 @@ export interface EventCardProps {
   onRequestJoin?: (eventId: string) => Promise<void>;
   onCancelParticipation?: (eventId: string) => Promise<void>;
   onUndoRequest?: (eventId: string) => Promise<void>;
-  onAcceptInvitation?: (eventId: string, invitationId?: string) => Promise<void>;
-  onRejectInvitation?: (eventId: string, invitationId?: string) => Promise<void>;
+  onAcceptInvitation?: (
+    eventId: string,
+    invitationId?: string
+  ) => Promise<void>;
+  onRejectInvitation?: (
+    eventId: string,
+    invitationId?: string
+  ) => Promise<void>;
   isActionLoading?: boolean;
   currentActionEventId?: string | null;
   testID?: string;

--- a/src/screens/profileScreen/components/FriendshipActions/useFriendshipActions.ts
+++ b/src/screens/profileScreen/components/FriendshipActions/useFriendshipActions.ts
@@ -33,7 +33,7 @@ export const useFriendshipActions = (
       setIsInitialLoading(true);
       const response = await friendshipsApi.getFriendshipStatus(userId);
       setFriendshipData(response as FriendshipData);
-    } catch (error) {
+    } catch {
       setFriendshipData({ status: null });
     } finally {
       setIsInitialLoading(false);
@@ -66,7 +66,7 @@ export const useFriendshipActions = (
       showToast('Solicitação enviada com sucesso', 'success');
       await fetchFriendshipStatus();
       onStatusChange?.();
-    } catch (error) {
+    } catch {
       showToast('Erro ao enviar solicitação de amizade', 'error');
     } finally {
       setIsLoading(false);
@@ -80,7 +80,7 @@ export const useFriendshipActions = (
       showToast('Solicitação cancelada', 'success');
       await fetchFriendshipStatus();
       onStatusChange?.();
-    } catch (error) {
+    } catch {
       showToast('Erro ao cancelar solicitação', 'error');
     } finally {
       setIsLoading(false);
@@ -96,12 +96,18 @@ export const useFriendshipActions = (
       showToast('Solicitação aceita', 'success');
       await fetchFriendshipStatus();
       onStatusChange?.();
-    } catch (error) {
+    } catch {
       showToast('Erro ao aceitar solicitação', 'error');
     } finally {
       setIsLoading(false);
     }
-  }, [userId, friendshipData, fetchFriendshipStatus, onStatusChange, showToast]);
+  }, [
+    userId,
+    friendshipData,
+    fetchFriendshipStatus,
+    onStatusChange,
+    showToast,
+  ]);
 
   const handleRejectRequest = useCallback(async () => {
     try {
@@ -110,7 +116,7 @@ export const useFriendshipActions = (
       showToast('Solicitação recusada', 'success');
       await fetchFriendshipStatus();
       onStatusChange?.();
-    } catch (error) {
+    } catch {
       showToast('Erro ao recusar solicitação', 'error');
     } finally {
       setIsLoading(false);
@@ -124,7 +130,7 @@ export const useFriendshipActions = (
       showToast('Amizade removida', 'success');
       await fetchFriendshipStatus();
       onStatusChange?.();
-    } catch (error) {
+    } catch {
       showToast('Erro ao remover amizade', 'error');
     } finally {
       setIsLoading(false);


### PR DESCRIPTION
## Summary
Final cleanup PR fixing remaining ESLint and Prettier errors introduced across all bug fixes.

## Changes

### Auto-fixed (Prettier)
1. **src/screens/groupDetailsScreen/index.tsx**
   - Fixed import statement formatting
   - Applied prettier formatting rules

2. **src/screens/homeScreen/components/EventCard/typesEventCard.ts**
   - Fixed function parameter formatting
   - Applied prettier formatting rules

### Manual Fixes
3. **src/screens/profileScreen/components/FriendshipActions/useFriendshipActions.ts**
   - Removed unused `error` parameters from all catch blocks
   - Catch blocks now use empty parameter list: `catch { ... }`
   - Fixed ESLint errors: `@typescript-eslint/no-unused-vars`

## Verification
✅ No TypeScript errors (`npx tsc --noEmit` passes)
✅ No ESLint errors  
⚠️ 3 minor warnings remaining (inline styles in FriendshipActions - acceptable)

## Test plan
- [ ] Verify application compiles successfully
- [ ] Run `npx tsc --noEmit` - should pass with no errors
- [ ] Run `npx eslint src --max-warnings=3` - should pass
- [ ] Test all previously fixed bugs to ensure nothing broke

🤖 Generated with [Claude Code](https://claude.com/claude-code)