### PR TITLE
fix: corrigir scroll travado no Android

### DIFF
--- a/src/screens/eventDetailsScreen/index.tsx
+++ b/src/screens/eventDetailsScreen/index.tsx
@@ -124,7 +124,6 @@ export const EventDetailsScreen: React.FC<EventDetailsScreenProps> = ({
         />
 
         <ScrollView
-          style={styles.scrollContent}
           contentContainerStyle={styles.scrollContainer}
           showsVerticalScrollIndicator={false}
         >

--- a/src/screens/eventDetailsScreen/stylesEventDetailsScreen.ts
+++ b/src/screens/eventDetailsScreen/stylesEventDetailsScreen.ts
@@ -6,9 +6,6 @@ export const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: ArenaColors.neutral.darkest,
   },
-  scrollContent: {
-    flex: 1,
-  },
   scrollContainer: {
     paddingHorizontal: ArenaSpacing.lg,
     paddingTop: ArenaSpacing['2xl'],


### PR DESCRIPTION
## 🐛 Problema

O scroll estava travado no Android na tela **EventDetailsScreen**. O problema era específico do Android - no iOS funcionava perfeitamente.

## 🔍 Causa Raiz

No Android, quando um `ScrollView` tem `style={{ flex: 1 }}`, o sistema não consegue calcular corretamente a altura do scroll, resultando em rolagem travada. Este é um bug conhecido específico da plataforma Android.

## ✅ Solução

**Antes (não scrollava no Android):**
```tsx
<ScrollView
  style={styles.scrollContent}  // ← Tinha flex: 1
  contentContainerStyle={styles.scrollContainer}
>
```

**Depois (scrolla perfeitamente):**
```tsx
<ScrollView
  contentContainerStyle={styles.scrollContainer}  // ← Sem style
>
```

**Estilos removidos:**
```tsx
// Removido do arquivo de estilos
scrollContent: {
  flex: 1,  // ← Esta linha causava o problema
},
```

## 📊 Arquivos Alterados

- `src/screens/eventDetailsScreen/index.tsx` - Removido prop `style` do ScrollView
- `src/screens/eventDetailsScreen/stylesEventDetailsScreen.ts` - Removido `scrollContent` style

## 🧪 Como Testar

1. Abrir o app no Android
2. Navegar para qualquer tela de detalhes de evento
3. Tentar scrollar a tela
4. ✅ O scroll deve funcionar normalmente

## 📱 Plataformas Testadas

- ✅ Android (corrigido)
- ✅ iOS (já funcionava, mantido funcionando)

## 🎯 Impacto

- **Severidade**: Alta (funcionalidade crítica quebrada no Android)
- **Escopo**: EventDetailsScreen
- **Regressão**: Nenhuma (outras telas não afetadas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)