### PR TITLE
fix(editProfile): adicionar safe area bottom ao footer

### DIFF
--- a/src/screens/editProfileScreen/index.tsx
+++ b/src/screens/editProfileScreen/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import { View, TouchableOpacity } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { AppLayout } from '@/components/AppLayout';
 import { ArenaKeyboardAwareScrollView } from '@/components/ui/arenaKeyboardAwareScrollView';
@@ -24,6 +25,8 @@ import { styles } from './stylesEditProfileScreen';
 export const EditProfileScreen: React.FC<EditProfileScreenProps> = ({
   navigation,
 }) => {
+  const insets = useSafeAreaInsets();
+
   const {
     formData,
     errors,
@@ -365,7 +368,7 @@ export const EditProfileScreen: React.FC<EditProfileScreenProps> = ({
         </View>
       </ArenaKeyboardAwareScrollView>
 
-      <View style={styles.footer}>
+      <View style={[styles.footer, { paddingBottom: insets.bottom || 12 }]}>
         <Button
           variant="primary"
           onPress={handleSave}

--- a/src/screens/editProfileScreen/stylesEditProfileScreen.ts
+++ b/src/screens/editProfileScreen/stylesEditProfileScreen.ts
@@ -107,9 +107,8 @@ export const styles = StyleSheet.create({
     marginTop: ArenaSpacing.xs,
   },
   footer: {
-    height: ArenaSpacing['6xl'],
     paddingHorizontal: ArenaSpacing.lg,
-    paddingVertical: ArenaSpacing.md,
+    paddingTop: ArenaSpacing.md,
     borderTopWidth: 1,
     borderTopColor: ArenaColors.neutral.dark,
     backgroundColor: ArenaColors.neutral.darkest,


### PR DESCRIPTION
## 🎯 Card 6: Footer button stuck (Edit Profile)

### Problema
- Footer do EditProfileScreen ficava **colado na borda inferior** sem considerar safe area
- `AppLayout` usa `edges={['top', 'left', 'right']}` **sem** `'bottom'`
- Em iOS (notch) e Android (gesture navigation), botão fica sobre o home indicator

### Solução
✅ Usar `useSafeAreaInsets()` hook para obter bottom inset dinamicamente  
✅ Aplicar `paddingBottom: insets.bottom || 12` no footer  
✅ Remover `height` fixo do footer, permitir conteúdo determinar altura

### Alterações
- **index.tsx**: Importar `useSafeAreaInsets`, aplicar `paddingBottom` dinâmico
- **stylesEditProfileScreen.ts**: Remover `height: ArenaSpacing['6xl']`, usar `paddingTop` apenas

### Cross-platform
- ✅ **iOS**: Respeita notch e home indicator
- ✅ **Android**: Respeita gesture navigation bar
- ✅ **Web**: Fallback para 12px quando `insets.bottom` é 0

### Testes
- [ ] iOS (iPhone com notch) - Footer com espaço adequado
- [ ] Android (gesture navigation) - Footer com espaço adequado
- [ ] Web - Footer com padding mínimo

🤖 Generated with [Claude Code](https://claude.com/claude-code)