### PR TITLE
fix(cityDropdown): normalizar strings para busca ignorar acentos

### DIFF
--- a/src/components/ui/cityDropdown/useCityDropdown.ts
+++ b/src/components/ui/cityDropdown/useCityDropdown.ts
@@ -8,6 +8,13 @@ import {
 const IBGE_API_BASE =
   'https://servicodados.ibge.gov.br/api/v1/localidades/estados';
 
+const normalizeString = (str: string): string => {
+  return str
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '');
+};
+
 export const useCityDropdown = ({
   stateUF,
   value,
@@ -78,8 +85,10 @@ export const useCityDropdown = ({
       return cities;
     }
 
-    const query = searchQuery.toLowerCase().trim();
-    return cities.filter(city => city.toLowerCase().includes(query));
+    const normalizedQuery = normalizeString(searchQuery.trim());
+    return cities.filter(city =>
+      normalizeString(city).includes(normalizedQuery)
+    );
   }, [cities, searchQuery]);
 
   return {


### PR DESCRIPTION
## 🎯 Card 9: City search não considera acentos

### Problema
- CityDropdown filter usa apenas `toLowerCase()`
- **Não remove acentos** antes de comparar
- Buscar "sao paulo" não encontra "São Paulo"
- Buscar "brasilia" não encontra "Brasília"
- Buscar "ribeirao preto" não encontra "Ribeirão Preto"

### Solução
✅ Criar função `normalizeString()` que:
  1. Converte para lowercase
  2. Remove acentos usando `normalize('NFD')`
  3. Remove diacríticos com regex `/[\u0300-\u036f]/g`

✅ Aplicar normalização tanto na **query** quanto nas **cities**

### Alterações
- **useCityDropdown.ts**: 
  - Adicionar `normalizeString()` helper function
  - Atualizar `filteredCities` para usar normalização

### Exemplos Funcionando
| Busca (sem acento) | Encontra (com acento) |
|--------------------|----------------------|
| "sao paulo"        | "São Paulo"          |
| "brasilia"         | "Brasília"           |
| "ribeirao preto"   | "Ribeirão Preto"     |
| "goiania"          | "Goiânia"            |

### Cross-platform
- ✅ **iOS**: String.normalize() suportado
- ✅ **Android**: String.normalize() suportado
- ✅ **Web**: String.normalize() suportado (ES6+)

### Testes
- [ ] Buscar cidade sem acentos encontra corretamente
- [ ] Buscar cidade com acentos também funciona
- [ ] Busca case-insensitive continua funcionando

🤖 Generated with [Claude Code](https://claude.com/claude-code)