### PR TITLE
fix(editProfile): adicionar padding base ao footer junto com safe area

### DIFF
--- a/src/screens/editProfileScreen/index.tsx
+++ b/src/screens/editProfileScreen/index.tsx
@@ -17,7 +17,7 @@ import { CityDropdown } from '@/components/ui/cityDropdown';
 import { Switch } from '@/components/ui/switch';
 import { OptimizedImage } from '@/components/ui/optimizedImage';
 import { SkillLevel } from '@/types/sport';
-import { ArenaColors } from '@/constants';
+import { ArenaColors, ArenaSpacing } from '@/constants';
 import { useEditProfileScreen } from './useEditProfileScreen';
 import { EditProfileScreenProps } from './typesEditProfileScreen';
 import { styles } from './stylesEditProfileScreen';
@@ -368,7 +368,12 @@ export const EditProfileScreen: React.FC<EditProfileScreenProps> = ({
         </View>
       </ArenaKeyboardAwareScrollView>
 
-      <View style={[styles.footer, { paddingBottom: insets.bottom || 12 }]}>
+      <View
+        style={[
+          styles.footer,
+          { paddingBottom: ArenaSpacing.md + (insets.bottom || 0) },
+        ]}
+      >
         <Button
           variant="primary"
           onPress={handleSave}


### PR DESCRIPTION
## Summary
- Ajusta padding do footer na tela Editar Perfil para usar padding base + safe area
- Resolve problema onde botão ficava completamente colado em dispositivos sem notch

## Changes
- `src/screens/editProfileScreen/index.tsx`: Altera cálculo de paddingBottom de `insets.bottom || 12` para `ArenaSpacing.md + (insets.bottom || 0)`

## Test plan
- [ ] Testar no iOS com notch (iPhone 12+)
- [ ] Testar no iOS sem notch (iPhone SE)
- [ ] Testar no Android com gestures
- [ ] Testar no Android com botões virtuais
- [ ] Verificar que há espaço respirável entre botão e borda inferior
- [ ] Comparar com outros formulários (Login, Register) para consistência

## Related
- Trello Card 6: "Botão de salvar colado na parte de baixo da tela"
- Continuação do PR #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)