### PR TITLE
fix(feedback): usar endpoint público para buscar participantes para avaliar

### DIFF
--- a/src/screens/rateParticipantsScreen/useRateParticipantsScreen.ts
+++ b/src/screens/rateParticipantsScreen/useRateParticipantsScreen.ts
@@ -60,24 +60,22 @@ export const useRateParticipantsScreen =
       try {
         setIsLoading(true);
 
-        const [eventData, participants, givenFeedbacks] = await Promise.all([
+        const [eventData, participantsResponse] = await Promise.all([
           eventsApi.getEventDetails(eventId),
-          eventsApi.getEventParticipants(eventId, 'confirmed'),
-          feedbackApi.getGivenFeedbacks(eventId),
+          feedbackApi.getParticipantsToRate(eventId),
         ]);
 
         setEvent(eventData);
-        setAlreadyRatedUserIds(givenFeedbacks);
+        setAlreadyRatedUserIds([]);
 
-        const participantsToRateData =
-          participants
-            ?.filter(p => !givenFeedbacks.includes(p.userId))
-            .map(p => ({
-              id: p.id,
-              userId: p.userId,
-              name: `${p.user.firstName} ${p.user.lastName}`,
-              avatar: p.user.profilePicture,
-            })) || [];
+        const participantsToRateData = participantsResponse.participants.map(
+          p => ({
+            id: p.id,
+            userId: p.userId,
+            name: p.name,
+            avatar: p.avatar,
+          })
+        );
 
         setParticipantsToRate(participantsToRateData);
       } catch (error) {

--- a/src/services/feedback/feedbackApi.ts
+++ b/src/services/feedback/feedbackApi.ts
@@ -34,6 +34,27 @@ export const feedbackApi = {
     return response.map(f => f.evaluatedId);
   },
 
+  async getParticipantsToRate(eventId: string): Promise<{
+    participants: Array<{
+      id: string;
+      userId: string;
+      name: string;
+      avatar?: string;
+    }>;
+    totalCount: number;
+  }> {
+    const response = await httpService.get<{
+      participants: Array<{
+        id: string;
+        userId: string;
+        name: string;
+        avatar?: string;
+      }>;
+      totalCount: number;
+    }>(`/feedback/event/${eventId}/participants-to-rate`);
+    return response;
+  },
+
   async getReceivedFeedbacks(limit = 20): Promise<ReceivedFeedback[]> {
     const response = await httpService.get<ReceivedFeedback[]>(
       `/feedback/received?limit=${limit}`


### PR DESCRIPTION
## 🎯 Objetivo

Atualizar frontend para consumir novo endpoint público de feedback que permite participantes normais acessarem lista de outros participantes para avaliar.

## 🐛 Problema

**Sintoma**: Todos os eventos mostravam "Nenhum participante confirmado" na tela de feedback, impedindo usuários de avaliar participantes.

**Causa no Frontend**:
- Hook `useRateParticipantsScreen` chamava `eventsApi.getEventParticipants(eventId, 'confirmed')`
- Esse endpoint backend é restrito apenas a organizador/owner
- Participantes normais recebiam **403 Forbidden**

## ✅ Solução

Consumir **novo endpoint público de feedback** criado no backend:

```
GET /feedback/event/:eventId/participants-to-rate
```

## 📁 Arquivos Alterados

### Frontend

1. **MODIFICADO**: `src/services/feedback/feedbackApi.ts`
   - Novo método: `getParticipantsToRate(eventId)`
   - Chama endpoint `/feedback/event/:eventId/participants-to-rate`
   - Retorna lista de participantes + totalCount

2. **MODIFICADO**: `src/screens/rateParticipantsScreen/useRateParticipantsScreen.ts`
   - Removida chamada: `eventsApi.getEventParticipants()` ❌
   - Nova chamada: `feedbackApi.getParticipantsToRate()` ✅
   - Removida chamada: `feedbackApi.getGivenFeedbacks()` (backend já filtra)
   - Lógica de filtragem movida para backend (mais seguro)

## 🔄 Mudanças de Lógica

### Antes (com problema)
```typescript
const [eventData, participants, givenFeedbacks] = await Promise.all([
  eventsApi.getEventDetails(eventId),
  eventsApi.getEventParticipants(eventId, 'confirmed'), // ❌ 403 Forbidden
  feedbackApi.getGivenFeedbacks(eventId),
]);

const participantsToRate = participants
  ?.filter(p => !givenFeedbacks.includes(p.userId))
  .map(p => ({ /* ... */ }));
```

### Agora (corrigido)
```typescript
const [eventData, participantsResponse] = await Promise.all([
  eventsApi.getEventDetails(eventId),
  feedbackApi.getParticipantsToRate(eventId), // ✅ Endpoint público
]);

const participantsToRate = participantsResponse.participants.map(
  p => ({ /* ... */ })
);
```

## 🎯 Benefícios

- ✅ **Menos lógica no frontend** - Filtragem feita no backend
- ✅ **Mais seguro** - Backend valida permissões corretamente
- ✅ **Mais eficiente** - Backend retorna apenas dados necessários
- ✅ **Código mais limpo** - Remoção de lógica duplicada de filtragem

## 🧪 Como Testar

1. Entre em um evento completado como participante CONFIRMED
2. Vá para a tela "Past Events"
3. Clique em "Dar Feedback" em algum evento
4. Verifique que a lista de participantes carrega corretamente
5. Avalie alguns participantes
6. Verifique que participantes avaliados somem da lista

## 🔗 Relacionado

- **Backend PR**: https://github.com/felipemlanna1/BackSportPulseMobile/pull/19 (já merged)
- **Endpoint novo**: `GET /feedback/event/:eventId/participants-to-rate`

## 📊 Impacto

- **Complexidade**: Baixa
- **Risco**: Baixo (apenas troca de endpoint)
- **Breaking changes**: Nenhum
- **Compatibilidade**: Requer backend atualizado (já deployado em dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)